### PR TITLE
Specify encoding "raw" when writing files on the disk

### DIFF
--- a/interchange/Vend/DataFilter.pm
+++ b/interchange/Vend/DataFilter.pm
@@ -81,7 +81,7 @@ sub datafilter {
 			$rfile = $source->{repository};
 		}
 		
-		Vend::Tags->write_relative_file($rfile, \$CGI::file{$source->{name}});
+		Vend::Tags->write_relative_file($rfile, { encoding => 'raw' }, \$CGI::file{$source->{name}});
 		unless (-f $rfile) {
 			Vend::Tags->error({name => 'datafilter', set => "Error writing $rfile: $!"});
 			return;
@@ -151,7 +151,7 @@ sub datafilter {
 	} else {
 		# we need to store the input as temporary file first
 		$tmpfile = "tmp/df-$Vend::Session->{id}-$Vend::Session->{pageCount}.xls";
-		Vend::Tags->write_relative_file($tmpfile, \$CGI::file{$source->{name}});
+		Vend::Tags->write_relative_file($tmpfile, { encoding => 'raw' }, \$CGI::file{$source->{name}});
 	}
 
 	my @extra_opts;


### PR DESCRIPTION
Without this, binary files with UTF-8 environment are mangled.

The first case was tested. The second was not, but there should be no sensible reason to encode file uploaded.
