### PR TITLE
Handle XLSX even if DataFilter was configured for XLS

### DIFF
--- a/lib/DataFilter.pm
+++ b/lib/DataFilter.pm
@@ -101,9 +101,13 @@ sub inout {
 			}
 		}
 	}		
-	
+	if ($class eq 'XLS' and $parms{name}) {
+        if ($parms{name} =~ m/\.xlsx$/i) {
+            $class = 'XLSX';
+        }
+    }
 	unless ($class) {
-		die "$0: Data type for " . ucfirst($type) . " and $parms{name} missing\n";
+		die "$0: Data type for " . ucfirst($type) . " and param name $parms{name} is missing\n";
 	}
 
 	if ($class =~ /\W/) {


### PR DESCRIPTION
Configuration right now when set on a file cannot be altered. Not sure it makes
sense to handle XLS and XLSX transparently. Probably it does. Otherwise this
commit should be reverted.